### PR TITLE
Translated using Weblate (Portuguese)

### DIFF
--- a/applications/luci-app-acme/po/fi/acme.po
+++ b/applications/luci-app-acme/po/fi/acme.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-03-12 13:29+0000\n"
+"PO-Revision-Date: 2022-03-15 00:58+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsacme/fi/>\n"
@@ -225,7 +225,7 @@ msgstr "Käytä nginx:ään"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Use for uhttpd"
-msgstr "Käytä uhhtpd:hen"
+msgstr "Käytä uhttpd:hen"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "Use staging server"

--- a/applications/luci-app-adblock/po/fi/adblock.po
+++ b/applications/luci-app-adblock/po/fi/adblock.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-03-13 12:25+0000\n"
+"PO-Revision-Date: 2022-03-15 00:58+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsadblock/fi/>\n"
@@ -218,7 +218,7 @@ msgstr "DNS-hakemisto"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "DNS Instance"
-msgstr ""
+msgstr "DNS-instanssi"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
@@ -260,7 +260,7 @@ msgstr "Verkkotunnus"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 msgid "Domains"
-msgstr ""
+msgstr "Verkkotunnukset"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Don't check SSL server certificates during download."
@@ -370,7 +370,7 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Fifth instance"
-msgstr ""
+msgstr "Viides instanssi"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -386,7 +386,7 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
 msgid "First instance (default)"
-msgstr ""
+msgstr "Ensimmäinen instanssi (oletus)"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Flush DNS Cache"
@@ -398,15 +398,15 @@ msgstr "Pakota paikallinen DNS"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
-msgstr ""
+msgstr "Pakotetut portit"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
-msgstr ""
+msgstr "Pakotetut alueet"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Fourth instance"
-msgstr ""
+msgstr "Neljäs instanssi"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
@@ -564,7 +564,7 @@ msgstr "Lataa uudelleen"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
-msgstr ""
+msgstr "Poista olemassa oleva työ"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:508
 msgid "Report Chunk Count"
@@ -596,7 +596,7 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:522
 msgid "Resolve IPs"
-msgstr ""
+msgstr "Selvitä IP:t"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:522
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
@@ -634,7 +634,7 @@ msgstr "Tallenna"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Second instance"
-msgstr ""
+msgstr "Toinen instanssi"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
@@ -648,7 +648,7 @@ msgstr "Lähettäjän osoite Adblockin sähköposti-ilmoituksille."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
-msgstr ""
+msgstr "Aseta uusi adblock-työ"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Set the dns backend instance used by adblock."
@@ -732,7 +732,7 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Third instance"
-msgstr ""
+msgstr "Kolmas instanssi"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
@@ -756,7 +756,7 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
-msgstr ""
+msgstr "Aika"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Timeout to wait for a successful DNS backend restart."
@@ -770,7 +770,7 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
-msgstr ""
+msgstr "Top 10 -tilastot"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:532
 msgid "Topic for adblock notification E-Mails."

--- a/applications/luci-app-aria2/po/fi/aria2.po
+++ b/applications/luci-app-aria2/po/fi/aria2.po
@@ -1,14 +1,14 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2021-06-18 19:32+0000\n"
-"Last-Translator: Demian Wright <wright.demian+weblate@gmail.com>\n"
+"PO-Revision-Date: 2022-03-13 23:16+0000\n"
+"Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsaria2/fi/>\n"
 "Language: fi\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.7\n"
+"X-Generator: Weblate 4.12-dev\n"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:433
 msgid "<abbr title=\"Local Peer Discovery\">LPD</abbr> enabled"
@@ -50,19 +50,19 @@ msgstr ""
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:204
 msgid "Basic Options"
-msgstr ""
+msgstr "Perusasetukset"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:413
 msgid "BitTorrent Options"
-msgstr ""
+msgstr "BitTorrent-asetukset"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:472
 msgid "BitTorrent listen port"
-msgstr ""
+msgstr "BitTorrentin kuunteluportti"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:329
 msgid "CA certificate"
-msgstr ""
+msgstr "CA-varmenne"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:334
 msgid "Certificate"
@@ -105,7 +105,7 @@ msgstr ""
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:478
 msgid "DHT Listen port"
-msgstr ""
+msgstr "DHT:n kuunteluportti"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:230
 msgid "Debug"
@@ -155,7 +155,7 @@ msgstr ""
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:220
 msgid "Enable logging"
-msgstr ""
+msgstr "Käytä lokitusta"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:442
 msgid "Enable peer exchange"
@@ -175,7 +175,7 @@ msgstr "Virhe"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:619
 msgid "Extra Settings"
-msgstr ""
+msgstr "Lisäasetukset"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:487
 msgid "False"
@@ -220,7 +220,7 @@ msgstr ""
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:304
 msgid "HTTP/FTP/SFTP Options"
-msgstr ""
+msgstr "HTTP/FTP/SFTP-asetukset"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:364
 msgid "Header"
@@ -375,7 +375,7 @@ msgstr "Huomaa"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:242
 msgid "Pause"
-msgstr ""
+msgstr "Keskeytä"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:242
 msgid "Pause download after added."
@@ -660,11 +660,11 @@ msgstr ""
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:36
 msgid "The Aria2 service is not running."
-msgstr ""
+msgstr "Aria2-palvelu ei ole käynnissä."
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:35
 msgid "The Aria2 service is running."
-msgstr ""
+msgstr "Aria2-palvelu on käynnissä."
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:217
 msgid "The directory to store the config file, session file and DHT file."
@@ -745,11 +745,11 @@ msgstr ""
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:408
 msgid "User agent"
-msgstr ""
+msgstr "Käyttäjäagentti"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:259
 msgid "Username & Password"
-msgstr ""
+msgstr "Käyttäjätunnus ja salasana"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:323
 msgid ""

--- a/applications/luci-app-banip/po/fi/banip.po
+++ b/applications/luci-app-banip/po/fi/banip.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-03-12 13:29+0000\n"
+"PO-Revision-Date: 2022-03-15 00:58+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsbanip/fi/>\n"
@@ -596,7 +596,7 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:62
 msgid "Remove an existing job"
-msgstr ""
+msgstr "Poista olemassa oleva työ"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"

--- a/applications/luci-app-ddns/po/pt/ddns.po
+++ b/applications/luci-app-ddns/po/pt/ddns.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: luci-app-ddns 2.4.0-1\n"
 "POT-Creation-Date: 2016-01-30 11:07+0100\n"
-"PO-Revision-Date: 2021-06-13 21:32+0000\n"
-"Last-Translator: ssantos <ssantos@web.de>\n"
+"PO-Revision-Date: 2022-03-16 09:23+0000\n"
+"Last-Translator: moonlightz <hugo.simoes.1984@gmail.com>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsddns/pt/>\n"
 "Language: pt\n"
@@ -11,7 +11,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.7-dev\n"
+"X-Generator: Weblate 4.12-dev\n"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:430
 msgid "\"../\" not allowed in path for Security Reason."
@@ -32,7 +32,7 @@ msgstr "Permitir IP's não-públicos"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:604
 msgid "Basic Settings"
-msgstr "Configurações Básicas"
+msgstr "Definições Básicas"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:884
 msgid "Bind Network"
@@ -40,7 +40,7 @@ msgstr "Ligar Rede"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:330
 msgid "Binding to a specific network not supported"
-msgstr "Ligação a uma rede específica não suportada"
+msgstr "Ligar a uma rede específica não suportada"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:357
 msgid ""
@@ -110,7 +110,7 @@ msgstr "Criar serviço"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:412
 msgid "Current setting:"
-msgstr "Configuração atual:"
+msgstr "Definição atual:"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:196
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:274

--- a/applications/luci-app-dnscrypt-proxy/po/fi/dnscrypt-proxy.po
+++ b/applications/luci-app-dnscrypt-proxy/po/fi/dnscrypt-proxy.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-03-12 13:29+0000\n"
+"PO-Revision-Date: 2022-03-13 23:16+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsdnscrypt-proxy/fi/>\n"
@@ -308,7 +308,7 @@ msgstr ""
 
 #: applications/luci-app-dnscrypt-proxy/luasrc/controller/dnscrypt-proxy.lua:20
 msgid "View Logfile"
-msgstr ""
+msgstr "Näytä lokitiedosto"
 
 #: applications/luci-app-dnscrypt-proxy/luasrc/controller/dnscrypt-proxy.lua:25
 msgid "View Resolver List"

--- a/applications/luci-app-dockerman/po/fi/dockerman.po
+++ b/applications/luci-app-dockerman/po/fi/dockerman.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-03-13 12:25+0000\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsdockerman/fi/>\n"
@@ -312,7 +312,7 @@ msgstr "Lataus"
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/newnetwork.lua:32
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/volumes.lua:85
 msgid "Driver"
-msgstr ""
+msgstr "Ajuri"
 
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/container.lua:263
 msgid "Duplicate/Edit"
@@ -795,7 +795,7 @@ msgstr "Aloita"
 
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/container.lua:311
 msgid "Start Time"
-msgstr ""
+msgstr "Käynnistysaika"
 
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/container.lua:780
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/container.lua:781

--- a/applications/luci-app-hd-idle/po/pt/hd-idle.po
+++ b/applications/luci-app-hd-idle/po/pt/hd-idle.po
@@ -3,8 +3,8 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2010-04-14 10:33+0200\n"
-"PO-Revision-Date: 2021-10-31 13:37+0000\n"
-"Last-Translator: ssantos <ssantos@web.de>\n"
+"PO-Revision-Date: 2022-03-16 09:23+0000\n"
+"Last-Translator: moonlightz <hugo.simoes.1984@gmail.com>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationshd-idle/pt/>\n"
 "Language: pt\n"
@@ -12,11 +12,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.9-dev\n"
+"X-Generator: Weblate 4.12-dev\n"
 
 #: applications/luci-app-hd-idle/htdocs/luci-static/resources/view/hd_idle.js:43
 msgid "Add new hdd setting..."
-msgstr "Adicionar uma nova configuração de hdd..."
+msgstr "Adicionar uma nova definição de hdd..."
 
 #: applications/luci-app-hd-idle/htdocs/luci-static/resources/view/hd_idle.js:61
 msgid "Bus"
@@ -28,7 +28,7 @@ msgstr "Disco"
 
 #: applications/luci-app-hd-idle/htdocs/luci-static/resources/view/hd_idle.js:46
 msgid "Disk Settings"
-msgstr "Configurações do disco"
+msgstr "Definições do disco"
 
 #: applications/luci-app-hd-idle/htdocs/luci-static/resources/view/hd_idle.js:49
 msgid "Enable"
@@ -48,8 +48,8 @@ msgid ""
 "HDD Idle is a utility program for spinning-down disks after a period of idle "
 "time."
 msgstr ""
-"HDD Idle é um programa utilitário para activar o modo \"economia de energia"
-"\" (spinning-down) de discos após um período de ociosidade."
+"HDD Idle é um programa utilitário para ativar o modo \"economia de energia\" "
+"(spinning-down) de discos após um período de ociosidade."
 
 #: applications/luci-app-hd-idle/htdocs/luci-static/resources/view/hd_idle.js:75
 #: applications/luci-app-hd-idle/htdocs/luci-static/resources/view/hd_idle.js:87
@@ -62,11 +62,11 @@ msgstr "Unidade de tempo de ociosidade"
 
 #: applications/luci-app-hd-idle/htdocs/luci-static/resources/view/hd_idle.js:39
 msgid "Settings"
-msgstr "Configurações"
+msgstr "Definições"
 
 #: applications/luci-app-hd-idle/htdocs/luci-static/resources/view/hd_idle.js:68
 msgid "Vendor / Model"
-msgstr "Fornecedor / modelo"
+msgstr "Fabricante / modelo"
 
 #: applications/luci-app-hd-idle/htdocs/luci-static/resources/view/hd_idle.js:84
 msgctxt "Abbreviation for days"

--- a/applications/luci-app-minidlna/po/fi/minidlna.po
+++ b/applications/luci-app-minidlna/po/fi/minidlna.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"PO-Revision-Date: 2022-03-12 13:29+0000\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsminidlna/fi/>\n"
@@ -102,7 +102,7 @@ msgstr ""
 
 #: applications/luci-app-minidlna/htdocs/luci-static/resources/view/minidlna.js:103
 msgid "Notify interval"
-msgstr ""
+msgstr "Ilmoitusväli"
 
 #: applications/luci-app-minidlna/htdocs/luci-static/resources/view/minidlna.js:103
 msgid "Notify interval in seconds."

--- a/applications/luci-app-nextdns/po/fi/nextdns.po
+++ b/applications/luci-app-nextdns/po/fi/nextdns.po
@@ -1,14 +1,14 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2021-06-18 19:32+0000\n"
-"Last-Translator: Demian Wright <wright.demian+weblate@gmail.com>\n"
+"PO-Revision-Date: 2022-03-13 23:16+0000\n"
+"Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsnextdns/fi/>\n"
 "Language: fi\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.7\n"
+"X-Generator: Weblate 4.12-dev\n"
 
 #: applications/luci-app-nextdns/root/usr/share/luci/menu.d/luci-app-nextdns.json:24
 msgid "Configuration"
@@ -16,7 +16,7 @@ msgstr "Kokoonpano"
 
 #: applications/luci-app-nextdns/htdocs/luci-static/resources/view/nextdns/overview.js:23
 msgid "Configuration ID"
-msgstr "Määrityksen ID"
+msgstr "Kokoonpanon ID"
 
 #: applications/luci-app-nextdns/htdocs/luci-static/resources/view/nextdns/overview.js:19
 msgid "Enable NextDNS."
@@ -44,7 +44,7 @@ msgstr "Yleinen"
 
 #: applications/luci-app-nextdns/htdocs/luci-static/resources/view/nextdns/overview.js:26
 msgid "Go to nextdns.io to create a configuration."
-msgstr "Mene sivustolle nextdns.io ja luo määritys."
+msgstr "Mene sivustolle nextdns.io ja luo kokonpano."
 
 #: applications/luci-app-nextdns/root/usr/share/rpcd/acl.d/luci-app-nextdns.json:3
 msgid "Grant logread access to LuCI app nextdns"

--- a/applications/luci-app-nft-qos/po/fi/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/fi/nft-qos.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-03-13 12:25+0000\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsnft-qos/fi/>\n"
@@ -108,12 +108,12 @@ msgstr "IP-osoite"
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:135
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:168
 msgid "IP Address (v4 / v6)"
-msgstr ""
+msgstr "IP-osoite (v4 / v6)"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:137
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:170
 msgid "IP Address (v4 Only)"
-msgstr ""
+msgstr "IP-osoite (vain v4)"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:40
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:105
@@ -130,7 +130,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:177
 msgid "MAC (optional)"
-msgstr ""
+msgstr "MAC (valinnainen)"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:248
 msgid "MAC Address"
@@ -138,11 +138,11 @@ msgstr "MAC-osoite"
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:48
 msgid "MB"
-msgstr ""
+msgstr "Mt"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:29
 msgid "NFT-QoS Settings"
-msgstr ""
+msgstr "NFT-QoS-asetukset"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:116
 msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
@@ -163,7 +163,7 @@ msgstr "Ei tietoja saatavilla"
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:137
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:156
 msgid "Packets Total"
-msgstr ""
+msgstr "Paketteja yhteensä"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:212
 msgid "Priority"

--- a/applications/luci-app-ntpc/po/fi/ntpc.po
+++ b/applications/luci-app-ntpc/po/fi/ntpc.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2010-04-14 13:24+0200\n"
-"PO-Revision-Date: 2022-03-12 13:29+0000\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsntpc/fi/>\n"
@@ -57,11 +57,11 @@ msgstr "Synkronoi järjestelmän ajan"
 
 #: applications/luci-app-ntpc/luasrc/model/cbi/ntpc/ntpcmini.lua:18
 msgid "Time Server"
-msgstr "Aika-palvelin"
+msgstr "Aikapalvelin"
 
 #: applications/luci-app-ntpc/luasrc/model/cbi/ntpc/ntpc.lua:29
 msgid "Time Servers"
-msgstr "Aika Palvelimet"
+msgstr "Aikapalvelimet"
 
 #: applications/luci-app-ntpc/luasrc/model/cbi/ntpc/ntpc.lua:5
 #: applications/luci-app-ntpc/luasrc/model/cbi/ntpc/ntpcmini.lua:6

--- a/applications/luci-app-nut/po/fi/nut.po
+++ b/applications/luci-app-nut/po/fi/nut.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"PO-Revision-Date: 2022-03-12 13:29+0000\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsnut/fi/>\n"
@@ -22,7 +22,7 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:23
 msgid "Allowed actions"
-msgstr ""
+msgstr "Sallitut toiminnot"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:20
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:188
@@ -36,11 +36,11 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:174
 msgid "CA Certificate path"
-msgstr ""
+msgstr "CA-varmenteen polku"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:73
 msgid "Certificate file (SSL)"
-msgstr ""
+msgstr "Varmennetiedosto (SSL)"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:63
 msgid "Communications lost message"
@@ -52,7 +52,7 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:35
 msgid "Control UPS via CGI"
-msgstr ""
+msgstr "Ohjaa UPS:ää CGI:n kautta"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:43
 msgid "Deadtime"
@@ -76,7 +76,7 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:32
 msgid "Display name"
-msgstr ""
+msgstr "Näyttönimi"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:169
 msgid "Don't lock port when starting driver"
@@ -84,23 +84,23 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:132
 msgid "Driver"
-msgstr ""
+msgstr "Ajuri"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:114
 msgid "Driver Configuration"
-msgstr ""
+msgstr "Ajurin määritys"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:77
 msgid "Driver Global Settings"
-msgstr ""
+msgstr "Ajurin yleiset asetukset"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:83
 msgid "Driver Path"
-msgstr ""
+msgstr "Ajurin polku"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:212
 msgid "Driver Shutdown Order"
-msgstr ""
+msgstr "Ajurin sammutusjärjestys"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:106
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:244
@@ -136,11 +136,11 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:26
 msgid "Forced Shutdown"
-msgstr ""
+msgstr "Pakotettu sammutus"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:57
 msgid "Forced shutdown message"
-msgstr ""
+msgstr "Pakotetun sammutuksen viesti"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:10
 msgid "Global Settings"
@@ -160,12 +160,12 @@ msgstr "Palvelin"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:23
 msgid "Hostname or IP address"
-msgstr ""
+msgstr "Laitenimi tai IP-osoite"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:191
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:220
 msgid "Hostname or address of UPS"
-msgstr ""
+msgstr "UPS-varavirtalähteen laitenimi tai osoite"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:39
 msgid "Hot Sync"
@@ -315,11 +315,11 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:90
 msgid "Notification defaults"
-msgstr ""
+msgstr "Ilmoituksen oletukset"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:26
 msgid "Notify command"
-msgstr ""
+msgstr "Ilmoituskomento"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:99
 msgid "Notify when back online"
@@ -386,7 +386,7 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:63
 msgid "Path to state file"
-msgstr ""
+msgstr "Polku tilatiedostoon"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:54
 msgid "Period after which data is considered stale"
@@ -453,11 +453,11 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:125
 msgid "SNMP Community"
-msgstr ""
+msgstr "SNMP-yhteisö"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:222
 msgid "SNMP retries"
-msgstr ""
+msgstr "SNMP-uudelleenyritykset"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:226
 msgid "SNMP timeout(s)"
@@ -465,39 +465,39 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:230
 msgid "SNMP version"
-msgstr ""
+msgstr "SNMP-versio"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:232
 msgid "SNMPv1"
-msgstr ""
+msgstr "SNMPv1"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:233
 msgid "SNMPv2c"
-msgstr ""
+msgstr "SNMPv2c"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:234
 msgid "SNMPv3"
-msgstr ""
+msgstr "SNMPv3"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:219
 msgid "Serial Number"
-msgstr ""
+msgstr "Sarjanumero"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:138
 msgid "Set USB serial port permissions"
-msgstr ""
+msgstr "Aseta USB-sarjaportin oikeudet"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:25
 msgid "Set variables"
-msgstr ""
+msgstr "Aseta muuttujat"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:22
 msgid "Shutdown command"
-msgstr ""
+msgstr "Sammutuskomento"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:66
 msgid "Shutdown message"
-msgstr ""
+msgstr "Sammutusviesti"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:33
 msgid "Slave"
@@ -526,7 +526,7 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:51
 msgid "UPS Server Global Settings"
-msgstr ""
+msgstr "UPS-palvelimen yleiset asetukset"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:212
 msgid "UPS Slave"
@@ -589,7 +589,7 @@ msgstr ""
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:159
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:167
 msgid "Write to syslog"
-msgstr ""
+msgstr "Kirjoita syslogiin"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:80
 msgid "chroot"

--- a/applications/luci-app-ocserv/po/fi/ocserv.po
+++ b/applications/luci-app-ocserv/po/fi/ocserv.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-03-12 13:29+0000\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsocserv/fi/>\n"
@@ -23,7 +23,7 @@ msgstr ""
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/users.lua:61
 msgid "Active users"
-msgstr ""
+msgstr "Aktiiviset käyttäjät"
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:74
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:64
@@ -37,7 +37,7 @@ msgstr ""
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:13
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:13
 msgid "CA certificate"
-msgstr ""
+msgstr "CA-varmenne"
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/users.lua:72
 #: applications/luci-app-ocserv/luasrc/view/ocserv_status.htm:57
@@ -51,7 +51,7 @@ msgstr "Kerätään tietoja…"
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:132
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:111
 msgid "DNS servers"
-msgstr ""
+msgstr "DNS-palvelimet"
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:60
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:54
@@ -76,7 +76,7 @@ msgstr ""
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:70
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:60
 msgid "Enable UDP"
-msgstr ""
+msgstr "Ota UDP käyttöön"
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:71
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:61
@@ -88,7 +88,7 @@ msgstr ""
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:66
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:67
 msgid "Enable compression"
-msgstr ""
+msgstr "Ota pakkaus käyttöön"
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:106
 msgid "Enable proxy arp"
@@ -106,7 +106,7 @@ msgstr ""
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:44
 msgid "Firewall Zone"
-msgstr ""
+msgstr "Palomuurin alue"
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:12
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:12
@@ -191,7 +191,7 @@ msgstr ""
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:143
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:122
 msgid "Routing table"
-msgstr ""
+msgstr "Reititystaulu"
 
 #: applications/luci-app-ocserv/luasrc/controller/ocserv.lua:20
 msgid "Server Settings"
@@ -199,7 +199,7 @@ msgstr "Palvelimen asetukset"
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:20
 msgid "Server's Public Key ID"
-msgstr ""
+msgstr "Palvelimen julkisen avaimen tunniste"
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/users.lua:73
 #: applications/luci-app-ocserv/luasrc/view/ocserv_status.htm:58
@@ -271,12 +271,12 @@ msgstr ""
 
 #: applications/luci-app-ocserv/luasrc/view/ocserv_status.htm:41
 msgid "There are no active users."
-msgstr ""
+msgstr "Ei aktiivisia käyttäjiä."
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/users.lua:71
 #: applications/luci-app-ocserv/luasrc/view/ocserv_status.htm:56
 msgid "Time"
-msgstr ""
+msgstr "Aika"
 
 #: applications/luci-app-ocserv/luasrc/view/ocserv_status.htm:51
 msgid "User"
@@ -285,11 +285,11 @@ msgstr "Käyttäjä"
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:49
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:37
 msgid "User Authentication"
-msgstr ""
+msgstr "Käyttäjän tunnistaminen"
 
 #: applications/luci-app-ocserv/luasrc/controller/ocserv.lua:25
 msgid "User Settings"
-msgstr ""
+msgstr "Käyttäjän asetukset"
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/users.lua:66
 msgid "Username"

--- a/applications/luci-app-olsr-services/po/fi/olsr-services.po
+++ b/applications/luci-app-olsr-services/po/fi/olsr-services.po
@@ -1,18 +1,18 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2020-06-24 17:42+0000\n"
-"Last-Translator: Petri Asikainen <uniluodossa@gmail.com>\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
+"Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsolsr-services/fi/>\n"
 "Language: fi\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.2-dev\n"
+"X-Generator: Weblate 4.12-dev\n"
 
 #: applications/luci-app-olsr-services/root/usr/share/rpcd/acl.d/luci-app-olsr-services.json:3
 msgid "Grant access to OLSRd config and services file"
-msgstr ""
+msgstr "Anna pääsy OLSRd:n määritys- ja palvelutiedostoihin"
 
 #: applications/luci-app-olsr-services/htdocs/luci-static/resources/view/freifunk-services/services.js:65
 msgid "Internal services"

--- a/applications/luci-app-olsr/po/fi/olsr.po
+++ b/applications/luci-app-olsr/po/fi/olsr.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-05-19 19:35+0200\n"
-"PO-Revision-Date: 2022-03-13 12:25+0000\n"
+"PO-Revision-Date: 2022-03-15 00:58+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsolsr/fi/>\n"
@@ -182,7 +182,7 @@ msgstr "Yleiset asetukset"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
-msgstr ""
+msgstr "Yleiset asetukset"
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/legend.htm:9
 msgid "Good (2 < ETX < 4)"
@@ -437,7 +437,7 @@ msgstr "Sovittimet"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
-msgstr ""
+msgstr "Sovittimien oletukset"
 
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:47
 msgid "Internet protocol"
@@ -468,7 +468,7 @@ msgstr ""
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/routes.htm:98
 msgid "Known OLSR routes"
-msgstr ""
+msgstr "Tunnetut OLSR-reitit"
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/topology.htm:24
 msgid "LQ"
@@ -505,7 +505,7 @@ msgstr ""
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/topology.htm:23
 msgid "Last hop"
-msgstr ""
+msgstr "Viimeinen hyppy"
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/legend.htm:1
 msgid "Legend"
@@ -516,12 +516,12 @@ msgstr ""
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
-msgstr ""
+msgstr "Kirjasto"
 
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
-msgstr ""
+msgstr "Linkin laatuasetukset"
 
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
@@ -685,7 +685,7 @@ msgstr ""
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:173
 msgid "Nodes"
-msgstr ""
+msgstr "Solmut"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:27
 msgid "OLSR"
@@ -723,7 +723,7 @@ msgstr ""
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:117
 msgid "OLSR connections"
-msgstr ""
+msgstr "OLSR-yhteydet"
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/hna.htm:40
 #: applications/luci-app-olsr/luasrc/view/status-olsr/hna.htm:91
@@ -735,7 +735,7 @@ msgstr ""
 #: applications/luci-app-olsr/luasrc/view/status-olsr/mid.htm:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/topology.htm:22
 msgid "OLSR node"
-msgstr ""
+msgstr "OLSR-solmu"
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/legend.htm:10
 #: applications/luci-app-olsr/luasrc/view/status-olsr/legend.htm:19
@@ -835,7 +835,7 @@ msgstr ""
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:56
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:108
 msgid "Selected"
-msgstr ""
+msgstr "Valittu"
 
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:133
 msgid ""
@@ -853,11 +853,11 @@ msgstr ""
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/common_js.htm:20
 msgid "Show IPv4"
-msgstr ""
+msgstr "Näytä IPv4"
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/common_js.htm:28
 msgid "Show IPv6"
-msgstr ""
+msgstr "Näytä IPv6"
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/legend.htm:14
 msgid "Signal Noise Ratio in dB"
@@ -986,7 +986,7 @@ msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:49
 msgid "Topology"
-msgstr ""
+msgstr "Topologia"
 
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60

--- a/applications/luci-app-opkg/po/fi/opkg.po
+++ b/applications/luci-app-opkg/po/fi/opkg.po
@@ -3,8 +3,8 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-06-10 03:40+0200\n"
-"PO-Revision-Date: 2021-11-16 17:38+0000\n"
-"Last-Translator: Hannu Nyman <hannu.nyman@iki.fi>\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
+"Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsopkg/fi/>\n"
 "Language: fi\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.9.1-dev\n"
+"X-Generator: Weblate 4.12-dev\n"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1044
 msgid "Actions"
@@ -20,7 +20,7 @@ msgstr "Toiminnot"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:850
 msgid "Automatically remove unused dependencies"
-msgstr "Poista tarpettomat riippuvuudet automaattisesti"
+msgstr "Poista tarpeettomat riippuvuudet automaattisesti"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1054
 msgid "Available"
@@ -33,10 +33,11 @@ msgid ""
 "custom repository entries. The configuration in the other files may be "
 "changed but is usually not preserved by <em>sysupgrade</em>."
 msgstr ""
-"Alla on luettelo <em> opkg: n </em> käyttämistä määrityksistä. Käytä <em> "
-"opkg.conf </em> yleisiä asetuksia varten ja <em> customfeeds.conf </em> "
-"mukautettujen arkistojen merkinnöille. Voit toki muuttaa myös muita "
-"tiedostoja, mutta <em> sysupgrade </em> ei yleensä säilytä muutoksia."
+"Alla on luettelo <em>opkg</em>:n käyttämistä määritystiedostoista. Käytä "
+"<em>opkg.conf</em>-tiedostoa yleisiä asetuksia varten ja <em>customfeeds."
+"conf</em>-tiedostoa mukautettujen arkistojen merkinnöille. Voit toki muuttaa "
+"myös muita tiedostoja, mutta <em>sysupgrade</em> ei yleensä säilytä "
+"muutoksia."
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:697
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:743
@@ -178,7 +179,7 @@ msgstr "OK"
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:801
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:815
 msgid "OPKG Configuration"
-msgstr "OPKG Määritys"
+msgstr "OPKG-määritys"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:692
 msgid "Overwrite files from other package(s)"
@@ -190,7 +191,7 @@ msgstr "Paketin nimi"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1038
 msgid "Package name or URL…"
-msgstr "Paketin nimi tai URL …"
+msgstr "Paketin nimi tai URL…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1061
 msgid "Previous page"
@@ -198,7 +199,7 @@ msgstr "Edellinen sivu"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:734
 msgid "Really attempt to install <em>%h</em>?"
-msgstr "Yritetäänkö todella asentaa <em>%h</em>?"
+msgstr "Yritätkö todella asentaa <em>%h</em>?"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:864
 msgid "Remove"
@@ -214,7 +215,7 @@ msgstr "Poista…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:665
 msgid "Require approx. %.1024mB size for %d package(s) to install."
-msgstr "Paketin/Pekettien %d asennus edellyttää noin %.1024mB tilaa."
+msgstr "%d paketin asennus edellyttää noin %.1024mB tilaa."
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:489
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:507
@@ -224,7 +225,9 @@ msgstr "Vaatii version %h %h, asennettu %h"
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:512
 msgid ""
 "Required dependency package <em>%h</em> is not available in any repository."
-msgstr "Vaadittava paketti <em>% h </em> ei ole käytettävissä missään."
+msgstr ""
+"Vaadittava riippuvuuspaketti <em>%h</em> ei ole saatavilla mistään "
+"ohjelmistolähteestä."
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:480
 msgid "Requires update to %h %h"
@@ -244,7 +247,7 @@ msgstr "Tallenna"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:802
 msgid "Saving configuration data…"
-msgstr "Tallennetaan määritystietoja …"
+msgstr "Tallennetaan määritystietoja…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:683
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:843
@@ -276,19 +279,20 @@ msgstr ""
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:730
 msgid "The package <em>%h</em> is not available in any configured repository."
 msgstr ""
-"Paketti <em>%h</em> ei ole käytettävissä missään määritetyssä lähteessä."
+"Paketti <em>%h</em> ei ole saatavilla mistään määritetystä "
+"ohjelmistolähteestä."
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:502
 msgid ""
 "The repository version of package <em>%h</em> is not compatible, require %s "
 "but only %s is available."
 msgstr ""
-"Paketti <em>%h</em> ei ole yhteensopiva is not compatible, vaaditaan%s mutta "
-"vain %s on käytettävissä."
+"Ohjelmistolähteen versio paketista <em>%h</em> ei ole yhteensopiva, "
+"vaaditaan %s mutta vain %s on saatavilla."
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1030
 msgid "Type to filter…"
-msgstr "Kirjoita suodatin…"
+msgstr "Kirjoita suodattaaksesi…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:925
 msgid "Unable to execute <em>opkg %s</em> command: %s"
@@ -317,7 +321,7 @@ msgstr "Päivitys…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1047
 msgid "Upload Package…"
-msgstr "Lähetä paketti …"
+msgstr "Lähetä paketti…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:682
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:842

--- a/applications/luci-app-opkg/po/pt/opkg.po
+++ b/applications/luci-app-opkg/po/pt/opkg.po
@@ -3,8 +3,8 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-05-26 19:03+0200\n"
-"PO-Revision-Date: 2020-05-03 18:57+0000\n"
-"Last-Translator: ssantos <ssantos@web.de>\n"
+"PO-Revision-Date: 2022-03-16 09:23+0000\n"
+"Last-Translator: moonlightz <hugo.simoes.1984@gmail.com>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsopkg/pt/>\n"
 "Language: pt\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.1-dev\n"
+"X-Generator: Weblate 4.12-dev\n"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1044
 msgid "Actions"
@@ -20,7 +20,7 @@ msgstr "Ações"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:850
 msgid "Automatically remove unused dependencies"
-msgstr "Remover automaticamente dependências não usadas"
+msgstr "Remover automaticamente dependências não utilizadas"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1054
 msgid "Available"
@@ -33,8 +33,8 @@ msgid ""
 "custom repository entries. The configuration in the other files may be "
 "changed but is usually not preserved by <em>sysupgrade</em>."
 msgstr ""
-"Abaixo encontra-se uma lista dos vários ficheiros de configuração usados "
-"pelo <em>opkg</em>. Use <em>opkg.conf</em> para definições globais e "
+"Em baixo está uma listagem dos vários ficheiros de configuração utilizados "
+"pelo <em>opkg</em>. Utilize <em>opkg.conf</em> para definições globais e "
 "<em>customfeeds.conf</em> para entradas de repositórios personalizados. A "
 "configuração dos outros ficheiros pode ser alterada mas geralmente não é "
 "preservada pelo <em>sysupgrade</em>."
@@ -99,7 +99,7 @@ msgstr "Espaço livre"
 
 #: applications/luci-app-opkg/root/usr/share/rpcd/acl.d/luci-app-opkg.json:3
 msgid "Grant access to opkg management"
-msgstr "Conceder acesso à gestão de opkg"
+msgstr "Conceder acesso à gestão do opkg"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:705
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:721
@@ -153,15 +153,15 @@ msgstr "Próxima página"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:345
 msgid "No information available"
-msgstr "Sem informação disponível"
+msgstr "Não há informação disponível"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:333
 msgid "No packages"
-msgstr "Sem pacotes"
+msgstr "Não há pacotes"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:349
 msgid "No packages matching \"<strong>%h</strong>\"."
-msgstr "Sem pacotes com correspondência a \"<strong>%h</strong>\"."
+msgstr "Não há pacotes com correspondência a \"<strong>%h</strong>\"."
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:514
 msgid "Not available"

--- a/applications/luci-app-p910nd/po/pt/p910nd.po
+++ b/applications/luci-app-p910nd/po/pt/p910nd.po
@@ -3,8 +3,8 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-05-26 19:03+0200\n"
-"PO-Revision-Date: 2020-05-02 10:21+0000\n"
-"Last-Translator: ssantos <ssantos@web.de>\n"
+"PO-Revision-Date: 2022-03-16 09:23+0000\n"
+"Last-Translator: moonlightz <hugo.simoes.1984@gmail.com>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsp910nd/pt/>\n"
 "Language: pt\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.1-dev\n"
+"X-Generator: Weblate 4.12-dev\n"
 
 #: applications/luci-app-p910nd/luasrc/model/cbi/p910nd.lua:47
 msgid "Bidirectional mode"
@@ -44,7 +44,7 @@ msgstr "Porta"
 
 #: applications/luci-app-p910nd/luasrc/model/cbi/p910nd.lua:14
 msgid "Settings"
-msgstr "Configurações"
+msgstr "Definições"
 
 #: applications/luci-app-p910nd/luasrc/model/cbi/p910nd.lua:22
 msgid "Specifies the interface to listen on."

--- a/applications/luci-app-ser2net/po/fi/ser2net.po
+++ b/applications/luci-app-ser2net/po/fi/ser2net.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-03-12 13:29+0000\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsser2net/fi/>\n"
@@ -49,7 +49,7 @@ msgstr "Laite"
 
 #: applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/leds.js:15
 msgid "Driver"
-msgstr ""
+msgstr "Ajuri"
 
 #: applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/leds.js:23
 msgid "Duration"

--- a/applications/luci-app-statistics/po/pt/statistics.po
+++ b/applications/luci-app-statistics/po/pt/statistics.po
@@ -3,8 +3,8 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-05-26 19:03+0200\n"
-"PO-Revision-Date: 2022-01-25 09:41+0000\n"
-"Last-Translator: ssantos <ssantos@web.de>\n"
+"PO-Revision-Date: 2022-03-15 15:17+0000\n"
+"Last-Translator: moonlightz <hugo.simoes.1984@gmail.com>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsstatistics/pt/>\n"
 "Language: pt\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.11-dev\n"
+"X-Generator: Weblate 4.12-dev\n"
 
 #: applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/apcups.js:7
 #: applications/luci-app-statistics/root/usr/share/luci/statistics/plugins/apcups.json:2
@@ -1620,7 +1620,7 @@ msgstr "Quando definido como verdadeiro solicitamos valores percentuais"
 #: applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/iwinfo.js:7
 #: applications/luci-app-statistics/root/usr/share/luci/statistics/plugins/iwinfo.json:2
 msgid "Wireless"
-msgstr "Wireless"
+msgstr "Rede sem fios"
 
 #: applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/iwinfo.js:7
 msgid "Wireless iwinfo Plugin Configuration"

--- a/applications/luci-app-tinyproxy/po/fi/tinyproxy.po
+++ b/applications/luci-app-tinyproxy/po/fi/tinyproxy.po
@@ -3,8 +3,8 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-05-19 19:35+0200\n"
-"PO-Revision-Date: 2021-06-18 19:32+0000\n"
-"Last-Translator: Demian Wright <wright.demian+weblate@gmail.com>\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
+"Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationstinyproxy/fi/>\n"
 "Language: fi\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.7\n"
+"X-Generator: Weblate 4.12-dev\n"
 
 #: applications/luci-app-tinyproxy/luasrc/model/cbi/tinyproxy.lua:219
 msgid ""
@@ -115,7 +115,7 @@ msgstr ""
 
 #: applications/luci-app-tinyproxy/luasrc/model/cbi/tinyproxy.lua:11
 msgid "General settings"
-msgstr ""
+msgstr "Yleiset asetukset"
 
 #: applications/luci-app-tinyproxy/root/usr/share/rpcd/acl.d/luci-app-tinyproxy.json:3
 msgid "Grant UCI access for luci-app-tinyproxy"

--- a/applications/luci-app-uhttpd/po/fi/uhttpd.po
+++ b/applications/luci-app-uhttpd/po/fi/uhttpd.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"PO-Revision-Date: 2022-03-12 13:29+0000\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsuhttpd/fi/>\n"
@@ -19,11 +19,11 @@ msgstr ""
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:145
 msgid "404 Error"
-msgstr ""
+msgstr "404-virhe"
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:7
 msgid "A lightweight single-threaded HTTP(S) server"
-msgstr ""
+msgstr "Kevyt, yksisäikeinen HTTP(S)-palvelin"
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:20
 msgid "Advanced Settings"
@@ -31,7 +31,7 @@ msgstr "Lisäasetukset"
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:135
 msgid "Aliases"
-msgstr ""
+msgstr "Aliakset"
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:149
 msgid "Base directory for files to be served"
@@ -108,23 +108,23 @@ msgstr "Yleiset asetukset"
 
 #: applications/luci-app-uhttpd/root/usr/share/rpcd/acl.d/luci-app-uhttpd.json:3
 msgid "Grant UCI access for luci-app-uhttpd"
-msgstr ""
+msgstr "Salli UCI-pääsy luci-app-uhttpd:lle"
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:22
 msgid "HTTP listeners (address:port)"
-msgstr ""
+msgstr "HTTP-kuuntelijat (osoite:portti)"
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:94
 msgid "HTTPS Certificate (DER or PEM format)"
-msgstr ""
+msgstr "HTTPS-varmenne (DER- tai PEM-muoto)"
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:96
 msgid "HTTPS Private Key (DER or PEM format)"
-msgstr ""
+msgstr "HTTPS:n yksityinen avain (DER- tai PEM-muoto)"
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:50
 msgid "HTTPS listener (address:port)"
-msgstr ""
+msgstr "HTTPS-kuuntelija (osoite:portti)"
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:221
 msgid "If empty, a random/unique value is used in cert generation"
@@ -154,7 +154,7 @@ msgstr ""
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:197
 msgid "Maximum number of connections"
-msgstr ""
+msgstr "Yhteyksien enimmäismäärä"
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:201
 msgid "Maximum number of script requests"
@@ -192,7 +192,7 @@ msgstr ""
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:86
 msgid "Redirect all HTTP to HTTPS"
-msgstr ""
+msgstr "Uudelleenohjaa kaikki HTTP-liikenne HTTPS:ksi"
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:109
 msgid "Remove configuration for certificate and key"

--- a/applications/luci-app-upnp/po/fi/upnp.po
+++ b/applications/luci-app-upnp/po/fi/upnp.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-05-19 19:36+0200\n"
-"PO-Revision-Date: 2022-03-12 13:29+0000\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsupnp/fi/>\n"
@@ -27,7 +27,7 @@ msgstr "Toiminta"
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Active UPnP Redirects"
-msgstr ""
+msgstr "Aktiivise UPnP-uudelleenohjaukset"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
@@ -84,7 +84,7 @@ msgstr "Kuvaus"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Device UUID"
-msgstr ""
+msgstr "Laitteen UUID"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
 msgid "Downlink"
@@ -100,7 +100,7 @@ msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP functionality"
-msgstr ""
+msgstr "Käytä UPnP-toiminnallisuutta"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
 msgid "Enable additional logging"
@@ -113,11 +113,11 @@ msgstr ""
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
 msgid "External Port"
-msgstr ""
+msgstr "Ulkoinen portti"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "External ports"
-msgstr ""
+msgstr "Ulkoiset portit"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
 msgid "General Settings"
@@ -134,11 +134,11 @@ msgstr "Palvelin"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
 msgid "Internal addresses"
-msgstr ""
+msgstr "Sisäiset osoitteet"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
 msgid "Internal ports"
-msgstr ""
+msgstr "Sisäiset portit"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
 msgid "MiniUPnP ACLs"
@@ -146,11 +146,11 @@ msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "MiniUPnP settings"
-msgstr ""
+msgstr "MiniUPnP-asetukset"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
 msgid "Notify interval"
-msgstr ""
+msgstr "Ilmoitusväli"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
 msgid "Port"
@@ -203,7 +203,7 @@ msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
 msgid "UPnP lease file"
-msgstr ""
+msgstr "UPnP-lainatiedosto"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "Universal Plug & Play"

--- a/applications/luci-app-vnstat2/po/fi/vnstat2.po
+++ b/applications/luci-app-vnstat2/po/fi/vnstat2.po
@@ -1,18 +1,18 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2021-06-18 19:32+0000\n"
-"Last-Translator: Demian Wright <wright.demian+weblate@gmail.com>\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
+"Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsvnstat2/fi/>\n"
 "Language: fi\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.7\n"
+"X-Generator: Weblate 4.12-dev\n"
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/graphs.js:57
 msgid "5 Minute"
-msgstr ""
+msgstr "5 minuuttia"
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js:21
 msgid "Cancel"
@@ -24,7 +24,7 @@ msgstr "Kokoonpano"
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/graphs.js:59
 msgid "Daily"
-msgstr ""
+msgstr "Päivittäin"
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js:26
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js:82
@@ -33,11 +33,11 @@ msgstr "Poista"
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js:15
 msgid "Delete interface <em>%h</em>"
-msgstr ""
+msgstr "Poista liityntä <em>%h</em>"
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js:95
 msgid "Delete…"
-msgstr ""
+msgstr "Poista…"
 
 #: applications/luci-app-vnstat2/root/usr/share/rpcd/acl.d/luci-app-vnstat2.json:3
 msgid "Grant access to LuCI app vnstat2"
@@ -49,7 +49,7 @@ msgstr "Kuvaajat"
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/graphs.js:58
 msgid "Hourly"
-msgstr ""
+msgstr "Tunneittain"
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js:81
 msgid "Interface"
@@ -61,7 +61,7 @@ msgstr "Sovittimet"
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/graphs.js:15
 msgid "Loading graphs…"
-msgstr ""
+msgstr "Ladataan kuvaajia…"
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js:49
 msgid "Monitor interfaces"
@@ -69,7 +69,7 @@ msgstr "Valvo sovittimia"
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/graphs.js:60
 msgid "Monthly"
-msgstr ""
+msgstr "Kuukausittain"
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/graphs.js:62
 msgid ""
@@ -83,7 +83,7 @@ msgstr ""
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/graphs.js:55
 msgid "Summary"
-msgstr ""
+msgstr "Yhteenveto"
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js:16
 msgid ""
@@ -113,7 +113,7 @@ msgstr ""
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/graphs.js:61
 msgid "Yearly"
-msgstr ""
+msgstr "Vuosittain"
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js:43
 msgid "vnStat"
@@ -121,11 +121,11 @@ msgstr ""
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/graphs.js:53
 msgid "vnStat Graphs"
-msgstr ""
+msgstr "vnStat-kuvaajat"
 
 #: applications/luci-app-vnstat2/root/usr/share/luci/menu.d/luci-app-vnstat2.json:3
 msgid "vnStat Traffic Monitor"
-msgstr ""
+msgstr "vnStat-liikennemonitorointi"
 
 #: applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js:43
 msgid ""

--- a/applications/luci-app-wifischedule/po/fi/wifischedule.po
+++ b/applications/luci-app-wifischedule/po/fi/wifischedule.po
@@ -1,18 +1,18 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2020-06-24 17:42+0000\n"
-"Last-Translator: Petri Asikainen <uniluodossa@gmail.com>\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
+"Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationswifischedule/fi/>\n"
 "Language: fi\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.2-dev\n"
+"X-Generator: Weblate 4.12-dev\n"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:81
 msgid "Activate wifi"
-msgstr ""
+msgstr "Aktivoi wifi"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:65
 msgid "Could not find required /usr/bin/wifi_schedule.sh or /sbin/wifi"
@@ -24,11 +24,11 @@ msgstr ""
 
 #: applications/luci-app-wifischedule/luasrc/controller/wifischedule/wifi_schedule.lua:45
 msgid "Cron Jobs"
-msgstr ""
+msgstr "Cron-työt"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:154
 msgid "Day(s) of Week"
-msgstr ""
+msgstr "Viikonpäivät"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:39
 msgid "Defines a schedule when to turn on and off wifi."
@@ -36,7 +36,7 @@ msgstr ""
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:133
 msgid "Determine Modules Automatically"
-msgstr ""
+msgstr "Määritä moduulit automaattisesti"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:88
 msgid "Disable wifi gracefully"
@@ -52,11 +52,11 @@ msgstr "Ota käyttöön"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:55
 msgid "Enable Wifi Schedule"
-msgstr ""
+msgstr "Käytä wifi-aikataulutusta"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:74
 msgid "Enable logging"
-msgstr ""
+msgstr "Käytä lokitusta"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:235
 msgid "Force disabling wifi even if stations associated"
@@ -84,27 +84,27 @@ msgstr "Lauantai"
 
 #: applications/luci-app-wifischedule/luasrc/controller/wifischedule/wifi_schedule.lua:31
 msgid "Schedule"
-msgstr ""
+msgstr "Aikataulu"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:142
 msgid "Schedule events"
-msgstr ""
+msgstr "Ajastetut tapahtumat"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:196
 msgid "Start Time"
-msgstr ""
+msgstr "Käynnistysaika"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:167
 msgid "Start WiFi"
-msgstr ""
+msgstr "Käynnistä wifi"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:230
 msgid "Stop Time"
-msgstr ""
+msgstr "Lopetusaika"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:201
 msgid "Stop WiFi"
-msgstr ""
+msgstr "Pysäytä wifi"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:163
 msgid "Sunday"
@@ -112,7 +112,7 @@ msgstr "Sunnuntai"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:33
 msgid "The value %s is invalid"
-msgstr ""
+msgstr "Arvo %s on virheellinen"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:160
 msgid "Thursday"
@@ -128,11 +128,11 @@ msgstr ""
 
 #: applications/luci-app-wifischedule/luasrc/controller/wifischedule/wifi_schedule.lua:33
 msgid "View Cron Jobs"
-msgstr ""
+msgstr "Näytä cron-työt"
 
 #: applications/luci-app-wifischedule/luasrc/controller/wifischedule/wifi_schedule.lua:32
 msgid "View Logfile"
-msgstr ""
+msgstr "Näytä lokitiedosto"
 
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:159
 msgid "Wednesday"
@@ -141,8 +141,8 @@ msgstr "Keskiviikko"
 #: applications/luci-app-wifischedule/luasrc/controller/wifischedule/wifi_schedule.lua:27
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:39
 msgid "Wifi Schedule"
-msgstr ""
+msgstr "Wifi-aikataulu"
 
 #: applications/luci-app-wifischedule/luasrc/controller/wifischedule/wifi_schedule.lua:39
 msgid "Wifi Schedule Logfile"
-msgstr ""
+msgstr "Wifi-aikataulun lokitiedosto"

--- a/applications/luci-app-yggdrasil/po/fi/yggdrasil.po
+++ b/applications/luci-app-yggdrasil/po/fi/yggdrasil.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-03-12 13:29+0000\n"
+"PO-Revision-Date: 2022-03-13 23:16+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsyggdrasil/fi/>\n"
@@ -41,19 +41,19 @@ msgstr ""
 #: applications/luci-app-yggdrasil/htdocs/luci-static/resources/view/yggdrasil/keys.js:11
 #: applications/luci-app-yggdrasil/root/usr/share/luci/menu.d/luci-app-yggdrasil.json:41
 msgid "Encryption keys"
-msgstr ""
+msgstr "Salausavaimet"
 
 #: applications/luci-app-yggdrasil/htdocs/luci-static/resources/view/yggdrasil/keys.js:15
 msgid "Encryption private key"
-msgstr ""
+msgstr "Salauksen yksityinen avain"
 
 #: applications/luci-app-yggdrasil/htdocs/luci-static/resources/view/yggdrasil/keys.js:14
 msgid "Encryption public key"
-msgstr ""
+msgstr "Salauksen julkinen avain"
 
 #: applications/luci-app-yggdrasil/htdocs/luci-static/resources/view/yggdrasil/settings.js:11
 msgid "General settings"
-msgstr ""
+msgstr "Yleiset asetukset"
 
 #: applications/luci-app-yggdrasil/root/usr/share/rpcd/acl.d/luci-app-yggdrasil.json:3
 msgid "Grant access to LuCI app yggdrasil"
@@ -93,7 +93,7 @@ msgstr ""
 
 #: applications/luci-app-yggdrasil/htdocs/luci-static/resources/view/yggdrasil/settings.js:33
 msgid "Listen addresses"
-msgstr ""
+msgstr "Kuuntele osoitteita"
 
 #: applications/luci-app-yggdrasil/htdocs/luci-static/resources/view/yggdrasil/settings.js:34
 msgid ""
@@ -134,7 +134,7 @@ msgstr "Vertaiset"
 
 #: applications/luci-app-yggdrasil/htdocs/luci-static/resources/view/yggdrasil/settings.js:49
 msgid "Regular expression"
-msgstr ""
+msgstr "Säännöllinen lauseke"
 
 #: applications/luci-app-yggdrasil/htdocs/luci-static/resources/view/yggdrasil/settings.js:50
 msgid "Send beacons"

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-06-10 03:41+0200\n"
-"PO-Revision-Date: 2022-03-06 15:26+0000\n"
+"PO-Revision-Date: 2022-03-15 00:58+0000\n"
 "Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/openwrt/luci/es/>"
 "\n"
@@ -7162,7 +7162,7 @@ msgstr "Establecer como primer esclavo agregado al vínculo (seguir, 2)"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:646
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 msgid "Set up DHCP Server"
-msgstr "Configuración del servidor DHCP"
+msgstr "Configurar servidor DHCP"
 
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:55
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:55

--- a/modules/luci-base/po/fi/base.po
+++ b/modules/luci-base/po/fi/base.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-03-13 16:07+0000\n"
+"PO-Revision-Date: 2022-03-13 23:16+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/luci/fi/>"
 "\n"
@@ -3174,7 +3174,7 @@ msgstr "Anna pääsy DHCP-määrityksiin"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json:22
 msgid "Grant access to DHCP status display"
-msgstr "Anna pääsy DHCP-tilanäyttöön"
+msgstr "Salli pääsy DHCP-tilanäyttöön"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json:31
 msgid "Grant access to DSL status display"
@@ -3210,7 +3210,7 @@ msgstr "Anna pääsy laiteohjemiston kirjoittamiseen"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json:3
 msgid "Grant access to main status display"
-msgstr "Anna pääsy päätilanäyttöön"
+msgstr "Salli pääsy päätilanäyttöön"
 
 #: protocols/luci-proto-modemmanager/root/usr/share/rpcd/acl.d/luci-proto-modemmanager.json:3
 msgid "Grant access to mmcli"
@@ -3266,7 +3266,7 @@ msgstr "Anna pääsy langattoman verkon kanavan tilaan"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json:40
 msgid "Grant access to wireless status display"
-msgstr "Anna pääsy langattoman verkon tilanäyttöön"
+msgstr "Salli pääsy langattoman tilan näyttöön"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:66
 msgid "Group Password"

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -3,8 +3,8 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-05-26 19:03+0200\n"
-"PO-Revision-Date: 2022-01-25 09:41+0000\n"
-"Last-Translator: ssantos <ssantos@web.de>\n"
+"PO-Revision-Date: 2022-03-16 09:23+0000\n"
+"Last-Translator: moonlightz <hugo.simoes.1984@gmail.com>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/openwrt/luci/"
 "pt/>\n"
 "Language: pt\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.11-dev\n"
+"X-Generator: Weblate 4.12-dev\n"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js:621
 msgctxt "Yet unknown nftables table family (\"family\" table \"name\")"
@@ -1609,7 +1609,7 @@ msgstr "Confirmação"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:47
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:51
 msgid "Connected"
-msgstr "Conectado"
+msgstr "Ligado"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-compat/luasrc/model/network.lua:27
@@ -2967,7 +2967,7 @@ msgstr "Ficheiro de Firmware"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/10_system.js:58
 msgid "Firmware Version"
-msgstr "Versão de firmware"
+msgstr "Versão do firmware"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:445
 msgid "Fixed source port for outbound DNS queries."
@@ -3249,7 +3249,7 @@ msgstr "Conceder acesso à configuração do DHCP"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json:22
 msgid "Grant access to DHCP status display"
-msgstr "Concedido o acesso à visualização do estado do DHCP"
+msgstr "Conceder o acesso à visualização do estado do DHCP"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json:31
 msgid "Grant access to DSL status display"
@@ -3285,7 +3285,7 @@ msgstr "Conceder acesso às operações flash"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json:3
 msgid "Grant access to main status display"
-msgstr "Concedido o acesso à visualização do estado principal"
+msgstr "Conceder o acesso à visualização do estado principal"
 
 #: protocols/luci-proto-modemmanager/root/usr/share/rpcd/acl.d/luci-proto-modemmanager.json:3
 msgid "Grant access to mmcli"
@@ -5323,7 +5323,7 @@ msgstr "Nenhuma rota para o host"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:362
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:59
 msgid "No information available"
-msgstr "Sem informação disponível"
+msgstr "Não há informação disponível"
 
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:63
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js:8
@@ -7154,7 +7154,7 @@ msgstr "A configuração do modo de operação falhou"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js:11
 msgid "Settings"
-msgstr "Configurações"
+msgstr "Definições"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Setup routes for proxied IPv6 neighbours."
@@ -9411,7 +9411,7 @@ msgstr "VPN WireGuard"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:10
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:141
 msgid "Wireless"
-msgstr "Wireless"
+msgstr "Rede sem fios"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2998
 #: modules/luci-compat/luasrc/model/network.lua:1419

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LuCI: base\n"
 "POT-Creation-Date: 2010-05-09 01:01+0300\n"
-"PO-Revision-Date: 2022-03-09 17:31+0000\n"
-"Last-Translator: Anton Kikin <a.a.kikin@gmail.com>\n"
+"PO-Revision-Date: 2022-03-15 23:07+0000\n"
+"Last-Translator: Alexey <agarkov.alexey.viktorovich@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/luci/ru/>"
 "\n"
 "Language: ru\n"
@@ -451,8 +451,7 @@ msgstr "Активные IPv4 маршруты"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
 msgid "Active IPv4 Rules"
-msgstr ""
-"Активные <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-правила"
+msgstr "Активные IPv4 правила"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:265
 msgid "Active IPv6 Routes"
@@ -460,8 +459,7 @@ msgstr "Активные IPv6 маршруты"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:268
 msgid "Active IPv6 Rules"
-msgstr ""
-"Активные <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-правила"
+msgstr "Активные IPv6 правила"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:205
 msgid "Active-Backup policy (active-backup, 1)"
@@ -3756,7 +3754,7 @@ msgstr "IPv6 суффикс"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:705
 msgid "IPv6 suffix (hex)"
-msgstr "<abbr title=\"Интернет протокол версии 6\">IPv6</abbr>-суффикс (hex)"
+msgstr "Суффикс IPv6 (hex)"
 
 #: protocols/luci-proto-sstp/htdocs/luci-static/resources/protocol/sstp.js:51
 msgid "IPv6 support"

--- a/modules/luci-mod-battstatus/po/fi/battstatus.po
+++ b/modules/luci-mod-battstatus/po/fi/battstatus.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"PO-Revision-Date: 2021-06-18 19:32+0000\n"
-"Last-Translator: Demian Wright <wright.demian+weblate@gmail.com>\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
+"Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "lucimodulesluci-mod-battstatus/fi/>\n"
 "Language: fi\n"
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.7\n"
+"X-Generator: Weblate 4.12-dev\n"
 
 #: modules/luci-mod-battstatus/htdocs/luci-static/resources/preload/battstatus.js:26
 msgid "Charging"
@@ -18,7 +18,7 @@ msgstr "Ladataan"
 
 #: modules/luci-mod-battstatus/root/usr/share/rpcd/acl.d/luci-mod-battstatus.json:3
 msgid "Grant access to battery status"
-msgstr "Myönnä pääsy akun tilan lukemiseen"
+msgstr "Anna pääsy akun tilan lukemiseen"
 
 #: modules/luci-mod-battstatus/htdocs/luci-static/resources/preload/battstatus.js:26
 msgid "Not Charging"

--- a/modules/luci-mod-dashboard/po/fi/dashboard.po
+++ b/modules/luci-mod-dashboard/po/fi/dashboard.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"PO-Revision-Date: 2022-03-12 13:29+0000\n"
+"PO-Revision-Date: 2022-03-13 23:17+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "lucimodulesluci-mod-dashboard/fi/>\n"
@@ -98,19 +98,19 @@ msgstr "GatewayV6"
 
 #: modules/luci-mod-dashboard/root/usr/share/rpcd/acl.d/luci-mod-dashboard.json:25
 msgid "Grant access to DHCP status display"
-msgstr ""
+msgstr "Salli pääsy DHCP-tilanäyttöön"
 
 #: modules/luci-mod-dashboard/root/usr/share/rpcd/acl.d/luci-mod-dashboard.json:12
 msgid "Grant access to main status display"
-msgstr ""
+msgstr "Salli pääsy päätilanäyttöön"
 
 #: modules/luci-mod-dashboard/root/usr/share/rpcd/acl.d/luci-mod-dashboard.json:3
 msgid "Grant access to the system route status"
-msgstr ""
+msgstr "Salli pääsy järjestelmän reitin tilaan"
 
 #: modules/luci-mod-dashboard/root/usr/share/rpcd/acl.d/luci-mod-dashboard.json:34
 msgid "Grant access to wireless status display"
-msgstr ""
+msgstr "Salli pääsy langattoman tilan näyttöön"
 
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/20_lan.js:30
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/30_wifi.js:83

--- a/modules/luci-mod-dashboard/po/pt/dashboard.po
+++ b/modules/luci-mod-dashboard/po/pt/dashboard.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"PO-Revision-Date: 2021-12-24 21:53+0000\n"
-"Last-Translator: Francisco Lopes <fmlopes@gmail.com>\n"
+"PO-Revision-Date: 2022-03-15 15:17+0000\n"
+"Last-Translator: moonlightz <hugo.simoes.1984@gmail.com>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/openwrt/"
 "lucimodulesluci-mod-dashboard/pt/>\n"
 "Language: pt\n"
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.10.1\n"
+"X-Generator: Weblate 4.12-dev\n"
 
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/30_wifi.js:163
 msgid "Active"
@@ -37,12 +37,12 @@ msgstr "Canal"
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/10_router.js:175
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/10_router.js:215
 msgid "Connected"
-msgstr "Conectado"
+msgstr "Ligado"
 
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/10_router.js:181
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/10_router.js:221
 msgid "Connected since"
-msgstr "Conectado desde"
+msgstr "Ligado desde"
 
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/20_lan.js:13
 msgid "DHCP Devices"
@@ -58,7 +58,7 @@ msgstr "DNSv6"
 
 #: modules/luci-mod-dashboard/root/usr/share/luci/menu.d/luci-mod-dashboard.json:3
 msgid "Dashboard"
-msgstr "Painel de Controle"
+msgstr "Painel de Controlo"
 
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/20_lan.js:134
 msgid "Devices"
@@ -66,7 +66,7 @@ msgstr "Dispositivos"
 
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/30_wifi.js:193
 msgid "Devices Connected"
-msgstr "Dispositivos conectados"
+msgstr "Dispositivos Ligados"
 
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/30_wifi.js:86
 msgid "Down."
@@ -82,7 +82,7 @@ msgstr "Encriptação"
 
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/10_router.js:311
 msgid "Firmware Version"
-msgstr "Versão de firmware"
+msgstr "Versão do firmware"
 
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/30_wifi.js:171
 msgid "GHz"
@@ -98,15 +98,15 @@ msgstr "GatewayV6"
 
 #: modules/luci-mod-dashboard/root/usr/share/rpcd/acl.d/luci-mod-dashboard.json:25
 msgid "Grant access to DHCP status display"
-msgstr "Concedido o acesso à visualização do estado do DHCP"
+msgstr "Conceder o acesso à visualização do estado do DHCP"
 
 #: modules/luci-mod-dashboard/root/usr/share/rpcd/acl.d/luci-mod-dashboard.json:12
 msgid "Grant access to main status display"
-msgstr "Concedido o acesso à visualização do estado principal"
+msgstr "Conceder o acesso à visualização do estado principal"
 
 #: modules/luci-mod-dashboard/root/usr/share/rpcd/acl.d/luci-mod-dashboard.json:3
 msgid "Grant access to the system route status"
-msgstr "Conceda acesso à condição da rota do sistema"
+msgstr "Conceder acesso ao estado da rota do sistema"
 
 #: modules/luci-mod-dashboard/root/usr/share/rpcd/acl.d/luci-mod-dashboard.json:34
 msgid "Grant access to wireless status display"
@@ -209,7 +209,7 @@ msgstr "Tempo de atividade"
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/30_wifi.js:9
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/30_wifi.js:84
 msgid "Wireless"
-msgstr "Rede sem fio"
+msgstr "Rede sem fios"
 
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/10_router.js:67
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/30_wifi.js:65


### PR DESCRIPTION
Currently translated at 100.0% (16 of 16 strings)

Translation: OpenWrt/LuCI/applications/hd-idle
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationshd-idle/pt/

Translated using Weblate (Portuguese)

Currently translated at 100.0% (196 of 196 strings)

Translation: OpenWrt/LuCI/applications/ddns
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsddns/pt/

Translated using Weblate (Portuguese)

Currently translated at 100.0% (72 of 72 strings)

Translated using Weblate (Portuguese)

Currently translated at 100.0% (11 of 11 strings)

Translated using Weblate (Portuguese)

Currently translated at 93.7% (1822 of 1944 strings)

Translation: OpenWrt/LuCI/modules/luci-base
Translate-URL: https://hosted.weblate.org/projects/openwrt/luci/pt/

Translated using Weblate (Russian)

Currently translated at 100.0% (1944 of 1944 strings)

Translation: OpenWrt/LuCI/modules/luci-base
Translate-URL: https://hosted.weblate.org/projects/openwrt/luci/ru/

Translated using Weblate (Portuguese)

Currently translated at 100.0% (49 of 49 strings)

Translated using Weblate (Portuguese)

Currently translated at 100.0% (343 of 343 strings)

Translated using Weblate (Portuguese)

Currently translated at 93.7% (1822 of 1944 strings)

Translation: OpenWrt/LuCI/modules/luci-base
Translate-URL: https://hosted.weblate.org/projects/openwrt/luci/pt/

Translated using Weblate (Finnish)

Currently translated at 21.0% (41 of 195 strings)

Translated using Weblate (Finnish)

Currently translated at 64.4% (116 of 180 strings)

Translation: OpenWrt/LuCI/applications/adblock
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsadblock/fi/

Translated using Weblate (Finnish)

Currently translated at 27.6% (54 of 195 strings)

Translation: OpenWrt/LuCI/applications/banip
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsbanip/fi/

Translated using Weblate (Finnish)

Currently translated at 62.0% (31 of 50 strings)

Translation: OpenWrt/LuCI/applications/acme
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsacme/fi/

Translated using Weblate (Spanish)

Currently translated at 91.7% (1784 of 1944 strings)

Translation: OpenWrt/LuCI/modules/luci-base
Translate-URL: https://hosted.weblate.org/projects/openwrt/luci/es/

Translated using Weblate (Finnish)

Currently translated at 100.0% (49 of 49 strings)

Translated using Weblate (Finnish)

Currently translated at 100.0% (3 of 3 strings)

Translated using Weblate (Finnish)

Currently translated at 19.4% (41 of 211 strings)

Translation: OpenWrt/LuCI/applications/dockerman
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsdockerman/fi/

Translated using Weblate (Finnish)

Currently translated at 14.5% (7 of 48 strings)

Translated using Weblate (Finnish)

Currently translated at 76.4% (26 of 34 strings)

Translation: OpenWrt/LuCI/applications/wifischedule
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationswifischedule/fi/

Translated using Weblate (Finnish)

Currently translated at 13.5% (10 of 74 strings)

Translated using Weblate (Finnish)

Currently translated at 18.1% (8 of 44 strings)

Translation: OpenWrt/LuCI/applications/ser2net
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsser2net/fi/

Translated using Weblate (Finnish)

Currently translated at 100.0% (6 of 6 strings)

Translation: OpenWrt/LuCI/applications/olsr-services
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsolsr-services/fi/

Translated using Weblate (Finnish)

Currently translated at 22.9% (14 of 61 strings)

Translated using Weblate (Finnish)

Currently translated at 28.5% (38 of 133 strings)

Translated using Weblate (Finnish)

Currently translated at 64.2% (18 of 28 strings)

Translation: OpenWrt/LuCI/applications/vnstat2
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsvnstat2/fi/

Translated using Weblate (Finnish)

Currently translated at 100.0% (72 of 72 strings)

Translated using Weblate (Finnish)

Currently translated at 100.0% (14 of 14 strings)

Translated using Weblate (Finnish)

Currently translated at 14.8% (29 of 195 strings)

Translated using Weblate (Finnish)

Currently translated at 42.8% (21 of 49 strings)

Translated using Weblate (Finnish)

Currently translated at 41.9% (26 of 62 strings)

Translation: OpenWrt/LuCI/applications/ocserv
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsocserv/fi/

Translated using Weblate (Finnish)

Currently translated at 26.3% (15 of 57 strings)

Translation: OpenWrt/LuCI/applications/nft-qos
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsnft-qos/fi/

Translated using Weblate (Finnish)

Currently translated at 15.4% (26 of 168 strings)

Translation: OpenWrt/LuCI/applications/aria2
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsaria2/fi/

Translated using Weblate (Finnish)

Currently translated at 7.6% (5 of 65 strings)

Translation: OpenWrt/LuCI/applications/dnscrypt-proxy
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsdnscrypt-proxy/fi/

Translated using Weblate (Finnish)

Currently translated at 57.2% (103 of 180 strings)

Translation: OpenWrt/LuCI/applications/adblock
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsadblock/fi/

Translated using Weblate (Finnish)

Currently translated at 32.2% (10 of 31 strings)

Translation: OpenWrt/LuCI/applications/yggdrasil
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsyggdrasil/fi/

Translated using Weblate (Finnish)

Currently translated at 100.0% (18 of 18 strings)

Translation: OpenWrt/LuCI/applications/nextdns
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsnextdns/fi/

Translated using Weblate (Finnish)

Currently translated at 86.8% (1688 of 1944 strings)

Translation: OpenWrt/LuCI/modules/luci-base
Translate-URL: https://hosted.weblate.org/projects/openwrt/luci/fi/

Co-authored-by: Alexey <agarkov.alexey.viktorovich@gmail.com>
Co-authored-by: Franco Castillo <castillofrancodamian@gmail.com>
Co-authored-by: Hosted Weblate <hosted@weblate.org>
Co-authored-by: Jiri Grönroos <jiri.gronroos@iki.fi>
Co-authored-by: moonlightz <hugo.simoes.1984@gmail.com>
Signed-off-by: Alexey <agarkov.alexey.viktorovich@gmail.com>
Signed-off-by: Franco Castillo <castillofrancodamian@gmail.com>
Signed-off-by: Jiri Grönroos <jiri.gronroos@iki.fi>
Signed-off-by: moonlightz <hugo.simoes.1984@gmail.com>
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsminidlna/fi/
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsntpc/fi/
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsnut/fi/
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsolsr/fi/
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsopkg/fi/
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsopkg/pt/
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsp910nd/pt/
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsstatistics/pt/
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationstinyproxy/fi/
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsuhttpd/fi/
Translate-URL: https://hosted.weblate.org/projects/openwrt/luciapplicationsupnp/fi/
Translate-URL: https://hosted.weblate.org/projects/openwrt/lucimodulesluci-mod-battstatus/fi/
Translate-URL: https://hosted.weblate.org/projects/openwrt/lucimodulesluci-mod-dashboard/fi/
Translate-URL: https://hosted.weblate.org/projects/openwrt/lucimodulesluci-mod-dashboard/pt/
Translation: OpenWrt/LuCI/applications/minidlna
Translation: OpenWrt/LuCI/applications/ntpc
Translation: OpenWrt/LuCI/applications/nut
Translation: OpenWrt/LuCI/applications/olsr
Translation: OpenWrt/LuCI/applications/opkg
Translation: OpenWrt/LuCI/applications/p910nd
Translation: OpenWrt/LuCI/applications/statistics
Translation: OpenWrt/LuCI/applications/tinyproxy
Translation: OpenWrt/LuCI/applications/uhttpd
Translation: OpenWrt/LuCI/applications/upnp
Translation: OpenWrt/LuCI/modules/luci-mod-battstatus
Translation: OpenWrt/LuCI/modules/luci-mod-dashboard